### PR TITLE
Add per-table sync date tracking and status reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+-   **Per-table sync date tracking**: Each table now maintains its own last sync date to prevent data loss when syncing individual tables
+-   New `--status` option to view sync history for all tables
+-   `GetLastSyncDateForTableAction` for retrieving table-specific sync dates
+-   `LogLastSyncDateForTableAction` for storing table-specific sync dates
+-   `GetLastSyncDateForTableWithFallbackAction` for intelligent sync date resolution with fallback support
+-   `GetAllTableSyncDatesAction` for retrieving sync status of all tables
+-   Debug output showing which sync date is being used for each table
+
+### Changed
+
+-   Sync process now uses table-specific dates when available, with automatic fallback to global dates
+-   Improved sync status information showing the date being used for each table
+-   Enhanced command description to mention the new `--status` option
+
+### Fixed
+
+-   Typo in sync message: "We will no start" → "We will now start"
+
 ## [1.0.0] - 2025-03-21
 
 ### Added
 
-- Initial release of Laravel Database Sync package
-- Command `db-sync` to synchronize data from a remote database to local
-- Support for multi-tenant database setups
-- Suite configuration for selective table synchronization
-- Date-based synchronization with options for today and yesterday
-- Configurable ignored tables
-- Support for Laravel 11.x and 12.x
-- Support for PHP 8.2 and 8.3
-- Comprehensive test suite with GitHub Actions CI
-- Storage system for tracking last sync dates
+-   Initial release of Laravel Database Sync package
+-   Command `db-sync` to synchronize data from a remote database to local
+-   Support for multi-tenant database setups
+-   Suite configuration for selective table synchronization
+-   Date-based synchronization with options for today and yesterday
+-   Configurable ignored tables
+-   Support for Laravel 11.x and 12.x
+-   Support for PHP 8.2 and 8.3
+-   Comprehensive test suite with GitHub Actions CI
+-   Storage system for tracking last sync dates

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A powerful Laravel package that enables seamless synchronization of data from a 
 -   [Usage](#usage)
     -   [Basic Synchronization](#basic-synchronization)
     -   [Advanced Options](#advanced-options)
+    -   [Per-Table Sync Tracking](#per-table-sync-tracking)
     -   [Table Configuration](#table-configuration)
     -   [Synchronization Suites](#synchronization-suites)
     -   [Multi-Tenant Support](#multi-tenant-support)
@@ -65,7 +66,7 @@ To sync your remote database to local:
 
 ```bash
 php artisan db-sync
-````
+```
 
 ### Advanced Options
 
@@ -83,6 +84,33 @@ Available options:
 -   `--tenant`: Specify tenant for multi-tenant applications
 -   `--skip-landlord`: Skip landlord database in multi-tenant setup
 -   `--full-sync`: Sync the full table without a date constraint
+-   `--status`: View the sync history and status for all tables
+
+### Per-Table Sync Tracking
+
+The package now tracks the last sync date for each individual table, preventing data loss when syncing single tables. This means:
+
+-   Each table maintains its own sync history
+-   When syncing a specific table with `--table`, only that table's sync date is considered
+-   The package automatically falls back to the global sync date for backward compatibility
+-   You can view the sync status of all tables using the `--status` option
+
+#### Viewing Sync Status
+
+To see the last sync date for all tables:
+
+```bash
+php artisan db-sync --status
+```
+
+This will display a table showing each table name and its last sync date, helping you track which tables have been synced recently and which might need attention.
+
+#### How It Works
+
+1. **Individual Table Tracking**: Each table's sync date is stored separately in the cache file
+2. **Automatic Fallback**: If no table-specific date exists, the global sync date is used
+3. **Backward Compatibility**: Existing installations continue to work without any changes
+4. **Debug Information**: When running with `-vvv` (debug mode), you'll see which sync date is being used for each table
 
 ### Table Configuration
 

--- a/docs/per-table-sync-example.md
+++ b/docs/per-table-sync-example.md
@@ -1,0 +1,61 @@
+# Per-Table Sync Example
+
+This example demonstrates how the new per-table sync tracking works.
+
+## Example Cache Structure
+
+After syncing some tables, your cache file (`storage/app/marshmallow/database-sync/cache.json`) will look like this:
+
+```json
+{
+    "my_production_db": {
+        "last_sync": "2025-06-25 14:30:00",
+        "tables": {
+            "users": {
+                "last_sync": "2025-06-25 14:30:00"
+            },
+            "orders": {
+                "last_sync": "2025-06-25 13:45:00"
+            },
+            "products": {
+                "last_sync": "2025-06-24 16:20:00"
+            }
+        }
+    }
+}
+```
+
+## Example Commands
+
+```bash
+# Sync all tables (each table uses its own last sync date)
+php artisan db-sync
+
+# Sync only the users table (uses users-specific sync date)
+php artisan db-sync --table=users
+
+# View sync status for all tables
+php artisan db-sync --status
+
+# Force sync from a specific date (ignores stored dates)
+php artisan db-sync --date=2025-06-20
+
+# Sync with debug output (shows which date is used for each table)
+php artisan db-sync -vvv
+```
+
+## Benefits
+
+1. **No Data Loss**: When syncing individual tables, you won't miss data because each table tracks its own sync date
+2. **Efficient Syncing**: Tables that were recently synced won't re-sync unnecessary data
+3. **Better Monitoring**: The `--status` option lets you see which tables need attention
+4. **Backward Compatible**: Existing installations continue to work without changes
+
+## Migration from Global Sync Dates
+
+If you're upgrading from a version that only tracked global sync dates:
+
+1. Your existing global sync date will be used as a fallback for tables without specific dates
+2. As you sync tables individually, they'll start tracking their own dates
+3. No data will be lost during the transition
+4. You can continue using the same commands as before

--- a/src/Actions/GetAllTableSyncDatesAction.php
+++ b/src/Actions/GetAllTableSyncDatesAction.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Marshmallow\LaravelDatabaseSync\Actions;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Marshmallow\LaravelDatabaseSync\Classes\Config;
+
+class GetAllTableSyncDatesAction
+{
+    public static function handle(Config $config): Collection
+    {
+        $cache = GetCacheFromStorageAction::handle($config);
+
+        if (!$cache) {
+            return collect();
+        }
+
+        $database_cache = Arr::get($cache, $config->remote_database);
+        if (!$database_cache) {
+            return collect();
+        }
+
+        $tables = Arr::get($database_cache, 'tables', []);
+
+        return collect($tables)->map(function ($table_data, $table_name) {
+            return [
+                'table' => $table_name,
+                'last_sync' => $table_data['last_sync'] ?? null,
+            ];
+        })->filter(function ($item) {
+            return $item['last_sync'] !== null;
+        })->sortBy('table');
+    }
+}

--- a/src/Actions/GetLastSyncDateForTableAction.php
+++ b/src/Actions/GetLastSyncDateForTableAction.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Marshmallow\LaravelDatabaseSync\Actions;
+
+use Carbon\Carbon;
+use Illuminate\Support\Arr;
+use Marshmallow\LaravelDatabaseSync\Classes\Config;
+
+class GetLastSyncDateForTableAction
+{
+    public static function handle(
+        string $table,
+        Config $config,
+    ): ?Carbon {
+        $cache = GetCacheFromStorageAction::handle($config);
+
+        if (!$cache) {
+            return null;
+        }
+
+        $database_cache = Arr::get($cache, $config->remote_database);
+        if (!$database_cache) {
+            return null;
+        }
+
+        $table_last_sync = Arr::get($database_cache, "tables.{$table}.last_sync");
+        if (!$table_last_sync) {
+            // Fall back to global last_sync for backward compatibility
+            $global_last_sync = Arr::get($database_cache, 'last_sync');
+            if (!$global_last_sync) {
+                return null;
+            }
+            return Carbon::parse($global_last_sync);
+        }
+
+        return Carbon::parse($table_last_sync);
+    }
+}

--- a/src/Actions/GetLastSyncDateForTableWithFallbackAction.php
+++ b/src/Actions/GetLastSyncDateForTableWithFallbackAction.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Marshmallow\LaravelDatabaseSync\Actions;
+
+use Carbon\Carbon;
+use Marshmallow\LaravelDatabaseSync\Classes\Config;
+use Marshmallow\LaravelDatabaseSync\Enums\SyncDateStartOption;
+use Marshmallow\LaravelDatabaseSync\Console\DatabaseSyncCommand;
+
+class GetLastSyncDateForTableWithFallbackAction
+{
+    public static function handle(
+        string $table,
+        Config $config,
+        DatabaseSyncCommand $command,
+    ): Carbon {
+        // If date option is provided via command line, use it
+        if ($command->option('date')) {
+            return Carbon::parse($command->option('date'));
+        }
+
+        // First try to get table-specific sync date
+        if ($last_sync_date = GetLastSyncDateForTableAction::handle($table, $config)) {
+            if ($command->isDebug()) {
+                $command->line(__("Using table-specific sync date for :table: :date", [
+                    'table' => $table,
+                    'date' => $last_sync_date->format('Y-m-d H:i:s'),
+                ]));
+            }
+            return $last_sync_date;
+        }
+
+        // If no table-specific date, try global sync date
+        if ($last_sync_date = GetLastSyncDateValueFromStorageAction::handle($config)) {
+            if ($command->isDebug()) {
+                $command->line(__("Using global sync date for :table: :date", [
+                    'table' => $table,
+                    'date' => $last_sync_date->format('Y-m-d H:i:s'),
+                ]));
+            }
+            return $last_sync_date;
+        }
+
+        // If no sync date at all, prompt user for start date
+        $command->alert(
+            __('No last sync date found for table :table in database :remote_database. Please provide a date to sync from.', [
+                'table' => $table,
+                'remote_database' => $config->remote_database,
+            ])
+        );
+        $command->info(__('🚀 Please note that you can also provide a date using the --date option.'));
+
+        $options = collect(SyncDateStartOption::cases())->mapWithKeys(function ($option) {
+            return ["$option->value" => $option->title()];
+        });
+
+        $sync_date_option = $command->choice(
+            __('From where do you want to sync :table from :remote_database?', [
+                'table' => $table,
+                'remote_database' => $config->remote_database,
+            ]),
+            $options->toArray(),
+            $options->flip()->first(),
+        );
+
+        return SyncDateStartOption::from($sync_date_option)->getDate();
+    }
+}

--- a/src/Actions/LogLastSyncDateForTableAction.php
+++ b/src/Actions/LogLastSyncDateForTableAction.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Marshmallow\LaravelDatabaseSync\Actions;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Storage;
+use Marshmallow\LaravelDatabaseSync\Classes\Config;
+
+class LogLastSyncDateForTableAction
+{
+    public static function handle(
+        string $table,
+        Config $config,
+    ): void {
+        $cache = GetCacheFromStorageAction::handle($config, default: [
+            $config->remote_database => [],
+        ]);
+
+        // Log the sync date for this specific table
+        Arr::set($cache, "{$config->remote_database}.tables.{$table}.last_sync", now()->format('Y-m-d H:i:s'));
+
+        // Also update the global last_sync for backward compatibility
+        Arr::set($cache, "{$config->remote_database}.last_sync", now()->format('Y-m-d H:i:s'));
+
+        Storage::disk($config->cache_file_disk)->put($config->cache_file_path, json_encode($cache));
+    }
+}

--- a/src/Actions/Mysql/CountRecordsAction.php
+++ b/src/Actions/Mysql/CountRecordsAction.php
@@ -33,9 +33,10 @@ class CountRecordsAction
             ]));
         }
 
-        $command->info(__(":table: syncing :count records", [
+        $command->info(__(":table: syncing :count records (from :date)", [
             'table' => $table,
             'count' => $count,
+            'date' => $config->date->format('Y-m-d H:i:s'),
         ]));
     }
 }

--- a/tests/Unit/TableSyncDateTest.php
+++ b/tests/Unit/TableSyncDateTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use Illuminate\Support\Facades\Storage;
+use Marshmallow\LaravelDatabaseSync\Classes\Config;
+use Marshmallow\LaravelDatabaseSync\Actions\LogLastSyncDateForTableAction;
+use Marshmallow\LaravelDatabaseSync\Actions\GetLastSyncDateForTableAction;
+
+beforeEach(function () {
+    Storage::fake('local');
+});
+
+test('can log and retrieve last sync date for specific table', function () {
+    $config = Config::make(
+        remote_user_and_host: 'test-remote-host@1.1.1.1',
+        remote_database: 'test-remote-db',
+        remote_database_username: 'test-user',
+        remote_database_password: 'test-password',
+        local_host: '127.0.0.1',
+        local_database: 'test-local-db',
+        local_database_username: 'test-user',
+        local_database_password: 'test-password'
+    );
+
+    $table = 'users';
+
+    // Log sync date for table
+    LogLastSyncDateForTableAction::handle($table, $config);
+
+    // Retrieve sync date for table
+    $syncDate = GetLastSyncDateForTableAction::handle($table, $config);
+
+    expect($syncDate)->not()->toBeNull()
+        ->and($syncDate->format('Y-m-d'))->toBe(now()->format('Y-m-d'));
+});
+
+test('falls back to global sync date when table-specific date not found', function () {
+    $config = Config::make(
+        remote_user_and_host: 'test-remote-host@1.1.1.1',
+        remote_database: 'test-remote-db',
+        remote_database_username: 'test-user',
+        remote_database_password: 'test-password',
+        local_host: '127.0.0.1',
+        local_database: 'test-local-db',
+        local_database_username: 'test-user',
+        local_database_password: 'test-password'
+    );
+
+    // Create a cache with only global sync date
+    $cache = [
+        'test-remote-db' => [
+            'last_sync' => '2025-06-24 10:00:00'
+        ]
+    ];
+
+    Storage::disk('local')->put('marshmallow/database-sync/cache.json', json_encode($cache));
+
+    // Try to get sync date for table that doesn't have specific sync date
+    $syncDate = GetLastSyncDateForTableAction::handle('posts', $config);
+
+    expect($syncDate)->not()->toBeNull()
+        ->and($syncDate->format('Y-m-d H:i:s'))->toBe('2025-06-24 10:00:00');
+});
+
+test('different tables can have different sync dates', function () {
+    $config = Config::make(
+        remote_user_and_host: 'test-remote-host@1.1.1.1',
+        remote_database: 'test-remote-db',
+        remote_database_username: 'test-user',
+        remote_database_password: 'test-password',
+        local_host: '127.0.0.1',
+        local_database: 'test-local-db',
+        local_database_username: 'test-user',
+        local_database_password: 'test-password'
+    );
+
+    // Log different sync dates for different tables
+    LogLastSyncDateForTableAction::handle('users', $config);
+    sleep(1); // Ensure different timestamps
+    LogLastSyncDateForTableAction::handle('orders', $config);
+
+    $usersSyncDate = GetLastSyncDateForTableAction::handle('users', $config);
+    $ordersSyncDate = GetLastSyncDateForTableAction::handle('orders', $config);
+
+    expect($usersSyncDate)->not()->toBeNull()
+        ->and($ordersSyncDate)->not()->toBeNull()
+        ->and($ordersSyncDate->isAfter($usersSyncDate))->toBeTrue();
+});
+
+test('can get all table sync dates', function () {
+    $config = Config::make(
+        remote_user_and_host: 'test-remote-host@1.1.1.1',
+        remote_database: 'test-remote-db',
+        remote_database_username: 'test-user',
+        remote_database_password: 'test-password',
+        local_host: '127.0.0.1',
+        local_database: 'test-local-db',
+        local_database_username: 'test-user',
+        local_database_password: 'test-password'
+    );
+
+    // Log sync dates for multiple tables
+    LogLastSyncDateForTableAction::handle('users', $config);
+    LogLastSyncDateForTableAction::handle('orders', $config);
+    LogLastSyncDateForTableAction::handle('products', $config);
+
+    $allSyncDates = \Marshmallow\LaravelDatabaseSync\Actions\GetAllTableSyncDatesAction::handle($config);
+
+    expect($allSyncDates)->toHaveCount(3)
+        ->and($allSyncDates->pluck('table')->toArray())->toContain('users', 'orders', 'products');
+});


### PR DESCRIPTION
Introduces per-table sync date tracking to prevent data loss when syncing individual tables. Adds new actions for logging and retrieving table-specific sync dates, a --status option to view sync history for all tables, and updates documentation and tests to reflect these changes. Sync process now uses table-specific dates with fallback to global dates for backward compatibility, and debug output shows which sync date is used for each table. Also fixes a typo in a sync message.