### PR TITLE
(feature) Add configurable process timeout for database sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A powerful Laravel package that enables seamless synchronization of data from a 
     -   [Advanced Options](#advanced-options)
     -   [Per-Table Sync Tracking](#per-table-sync-tracking)
     -   [Table Configuration](#table-configuration)
+    -   [Timeout Configuration](#timeout-configuration)
     -   [Synchronization Suites](#synchronization-suites)
     -   [Multi-Tenant Support](#multi-tenant-support)
 -   [Testing](#testing)
@@ -167,6 +168,30 @@ You can exclude specific tables from synchronization in the `config/database-syn
     ],
 ],
 ```
+
+### Timeout Configuration
+
+For large databases, you may need to adjust the process timeout to prevent operations from timing out:
+
+```php
+// Set timeout in seconds (default: 300 seconds / 5 minutes)
+'process_timeout' => 600, // 10 minutes
+
+// Or set to null to disable timeout entirely for very large databases
+'process_timeout' => null,
+```
+
+You can also set this via environment variable:
+
+```env
+DATABASE_SYNC_PROCESS_TIMEOUT=600
+```
+
+This timeout applies to:
+
+-   MySQL dump operations (`mysqldump`)
+-   MySQL import operations (`mysql`)
+-   File transfer operations (`scp`)
 
 ### Synchronization Suites
 

--- a/config/database-sync.php
+++ b/config/database-sync.php
@@ -119,4 +119,17 @@ return [
     'mysql' => [
         'dump_action_flags' => '--skip-lock-tables --no-create-info --complete-insert --skip-triggers --replace',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Process Timeout Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Set the timeout (in seconds) for long-running database operations.
+    | Set to null to disable timeout entirely for very large databases.
+    | Default: 300 seconds (5 minutes)
+    |
+    */
+
+    'process_timeout' => env('DATABASE_SYNC_PROCESS_TIMEOUT', 300),
 ];

--- a/docs/troubleshooting-large-databases.md
+++ b/docs/troubleshooting-large-databases.md
@@ -1,0 +1,81 @@
+# Troubleshooting Large Database Sync Issues
+
+## Timeout Errors
+
+If you encounter timeout errors like:
+
+```
+The process "mysql -h 127.0.0.1 -u root -p'***' example_database < ~/Downloads/new_data.sql" exceeded the timeout of 60 seconds.
+```
+
+### Solution
+
+Configure the `process_timeout` setting in your `config/database-sync.php` file:
+
+```php
+// Set timeout in seconds (default: 300 seconds / 5 minutes)
+'process_timeout' => 600, // 10 minutes
+
+// Or set to null to disable timeout entirely for very large databases
+'process_timeout' => null,
+```
+
+Or set via environment variable:
+
+```env
+DATABASE_SYNC_PROCESS_TIMEOUT=600
+```
+
+### Affected Operations
+
+The timeout setting applies to:
+
+-   MySQL dump operations (`mysqldump`)
+-   MySQL import operations (`mysql`)
+-   File transfer operations (`scp`)
+-   Remote file operations (`ssh rm`)
+
+### Recommendations by Database Size
+
+-   **Small databases (< 100MB)**: Default timeout (300 seconds) should be sufficient
+-   **Medium databases (100MB - 1GB)**: Set timeout to 600-1800 seconds (10-30 minutes)
+-   **Large databases (> 1GB)**: Consider setting timeout to `null` to disable it entirely
+
+### Alternative Solutions
+
+1. **Use batch transfer mode**: This is enabled by default and combines all table dumps into a single file transfer, which is more efficient for large databases.
+
+2. **Sync specific tables**: Use the `--table` option to sync only specific tables:
+
+    ```bash
+    php artisan db-sync --table=users
+    ```
+
+3. **Use suites**: Group related tables and sync them separately:
+
+    ```bash
+    php artisan db-sync --suite=orders
+    ```
+
+4. **Increase MySQL timeouts**: You may also need to adjust MySQL server timeouts:
+    ```sql
+    SET global net_read_timeout=600;
+    SET global net_write_timeout=600;
+    ```
+
+## Memory Issues
+
+For very large datasets, you may need to adjust PHP memory limits:
+
+```bash
+php -d memory_limit=512M artisan db-sync
+```
+
+## Network Issues
+
+If you experience network-related timeouts during file transfers:
+
+1. Ensure stable SSH connection to remote server
+2. Consider using compression in SSH config
+3. Check available disk space on both local and remote systems
+4. Verify network bandwidth between servers

--- a/src/Actions/CopyRemoteFileToLocalAction.php
+++ b/src/Actions/CopyRemoteFileToLocalAction.php
@@ -19,7 +19,9 @@ class CopyRemoteFileToLocalAction
             $command->info(__('Copying file to local machine...'));
         }
         $copyCommand = "scp {$config->remote_user_and_host}:{$config->remote_temporary_file} {$config->local_temporary_file}";
-        $result = Process::run($copyCommand);
+
+        $process = Process::timeout($config->process_timeout);
+        $result = $process->run($copyCommand);
 
         if ($result->failed()) {
             throw new \Exception(__('Failed to copy remote file to local: :error', ['error' => $result->errorOutput()]));

--- a/src/Actions/Mysql/DumpCreatedOrUpdatedDataAction.php
+++ b/src/Actions/Mysql/DumpCreatedOrUpdatedDataAction.php
@@ -26,6 +26,7 @@ class DumpCreatedOrUpdatedDataAction
             ]));
         }
 
-        Process::run($exportCommand)->output();
+        $process = Process::timeout($config->process_timeout);
+        $process->run($exportCommand)->output();
     }
 }

--- a/src/Actions/Mysql/DumpDeletedDataAction.php
+++ b/src/Actions/Mysql/DumpDeletedDataAction.php
@@ -31,6 +31,7 @@ class DumpDeletedDataAction
             ]));
         }
 
-        Process::run($exportCommand)->output();
+        $process = Process::timeout($config->process_timeout);
+        $process->run($exportCommand)->output();
     }
 }

--- a/src/Actions/Mysql/DumpFullTableDataAction.php
+++ b/src/Actions/Mysql/DumpFullTableDataAction.php
@@ -26,6 +26,7 @@ class DumpFullTableDataAction
             ]));
         }
 
-        Process::run($exportCommand)->output();
+        $process = Process::timeout($config->process_timeout);
+        $process->run($exportCommand)->output();
     }
 }

--- a/src/Actions/Mysql/ImportDataAction.php
+++ b/src/Actions/Mysql/ImportDataAction.php
@@ -18,7 +18,9 @@ class ImportDataAction
         }
 
         $importCommand = "mysql -h {$config->local_host} -u {$config->local_database_username} -p'{$config->local_database_password}' {$config->local_database} < {$config->local_temporary_file}";
-        $result = Process::run($importCommand);
+
+        $process = Process::timeout($config->process_timeout);
+        $result = $process->run($importCommand);
 
         if ($result->failed()) {
             throw new \Exception(__('Failed to import data to local database: :error', ['error' => $result->errorOutput()]));

--- a/src/Actions/RemoveLocalFileAction.php
+++ b/src/Actions/RemoveLocalFileAction.php
@@ -13,6 +13,7 @@ class RemoveLocalFileAction
         /**
          * Delete the local SQL dump file
          */
-        Process::run("rm -f {$config->local_temporary_file}");
+        $process = Process::timeout($config->process_timeout);
+        $process->run("rm -f {$config->local_temporary_file}");
     }
 }

--- a/src/Actions/RemoveRemoteFileAction.php
+++ b/src/Actions/RemoveRemoteFileAction.php
@@ -13,6 +13,7 @@ class RemoveRemoteFileAction
         /**
          * Delete the remote SQL dump file
          */
-        Process::run("ssh {$config->remote_user_and_host} 'rm -f {$config->remote_temporary_file}'");
+        $process = Process::timeout($config->process_timeout);
+        $process->run("ssh {$config->remote_user_and_host} 'rm -f {$config->remote_temporary_file}'");
     }
 }

--- a/src/Classes/Config.php
+++ b/src/Classes/Config.php
@@ -18,6 +18,7 @@ class Config
     public string $cache_file_path;
     public string $cache_file_disk;
     public ?Carbon $sync_start_time = null;
+    public ?int $process_timeout;
 
     public static function make(...$arguments): static
     {
@@ -38,6 +39,7 @@ class Config
 
         $this->remote_temporary_file = config('database-sync.temporary_file_location.remote');
         $this->local_temporary_file = config('database-sync.temporary_file_location.local');
+        $this->process_timeout = config('database-sync.process_timeout');
 
         // MAKE VARIABLE
         $this->cache_file_path = 'marshmallow/database-sync/cache.json';

--- a/tests/Unit/TimeoutConfigTest.php
+++ b/tests/Unit/TimeoutConfigTest.php
@@ -2,7 +2,9 @@
 
 use Marshmallow\LaravelDatabaseSync\Classes\Config;
 
-test('config can be created with valid parameters', function () {
+test('config sets custom timeout from configuration', function () {
+    config(['database-sync.process_timeout' => 600]);
+
     $config = Config::make(
         remote_user_and_host: 'test-remote-host@1.1.1.1',
         remote_database: 'test-remote-db',
@@ -14,17 +16,14 @@ test('config can be created with valid parameters', function () {
         local_database_password: 'test-password'
     );
 
-    expect($config)->toBeInstanceOf(Config::class)
-        ->and($config->remote_user_and_host)->toBe('test-remote-host@1.1.1.1')
-        ->and($config->remote_database)->toBe('test-remote-db')
-        ->and($config->local_host)->toBe('127.0.0.1')
-        ->and($config->local_database)->toBe('test-local-db')
-        ->and($config->process_timeout)->toBe(300); // Default timeout should be 300 seconds
+    expect($config->process_timeout)->toBe(600);
 });
 
-test('config validates required parameters', function () {
-    expect(fn() => Config::make(
-        remote_user_and_host: '',  // Empty host should throw exception
+test('config handles null timeout for disabling timeout', function () {
+    config(['database-sync.process_timeout' => null]);
+
+    $config = Config::make(
+        remote_user_and_host: 'test-remote-host@1.1.1.1',
         remote_database: 'test-remote-db',
         remote_database_username: 'test-user',
         remote_database_password: 'test-password',
@@ -32,5 +31,7 @@ test('config validates required parameters', function () {
         local_database: 'test-local-db',
         local_database_username: 'test-user',
         local_database_password: 'test-password'
-    ))->toThrow(\InvalidArgumentException::class, 'Remote host cannot be empty');
+    );
+
+    expect($config->process_timeout)->toBeNull();
 });


### PR DESCRIPTION
Introduces a 'process_timeout' setting to control the timeout for long-running operations such as MySQL dump/import and file transfers. Updates configuration, documentation, and all relevant actions to use the new timeout value. Adds tests to verify timeout configuration and handling of null (disabled) timeout.